### PR TITLE
Update gargoyle_firewall_util.sh

### DIFF
--- a/package/gargoyle-firewall-util/files/gargoyle_firewall_util.sh
+++ b/package/gargoyle-firewall-util/files/gargoyle_firewall_util.sh
@@ -543,7 +543,7 @@ enforce_dhcp_assignments()
 			ip=$(echo $p | sed 's/^.*\^//g')
 			if [ -n "$ip" ] && [ -n "$mac" ] ; then
 				iptables -t filter -A lease_mismatch_check  ! -s  "$ip"  -m mac --mac-source  "$mac"  -j REJECT
-				iptables -t filter -A lease_mismatch_check  -s  "$ip"  ! -m mac --mac-source  "$mac"  -j REJECT
+				iptables -t filter -A lease_mismatch_check  -s  "$ip"  -m mac ! --mac-source  "$mac"  -j REJECT
 			fi
 		done
 		iptables -t filter -I delegate_forward -j lease_mismatch_check


### PR DESCRIPTION
Enforce assignments : typo caused invalid iptables syntax.
I tested all cases and it now works as intended:
Known IP, wrong MAC : BLOCK
Known MAC, wrong IP : BLOCK
